### PR TITLE
Waveform noise generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,20 @@ Cross-Platform, out-of-the-box. Easily use in your Linux, Windows, MacOS, and Em
 * Get the current position in the sample, in milliseconds.
 * Get the current position in the sample, as float 0.0f is start, 1.0f is end.
 
+### Waveform Features
+* Create sine, square, sawtooth, and triangle waves.
+* Load and play multiple waveform channels at the same time.
+* Modify waveform amplitudes, frequencies, and types in realtime.
+
+### Noise Generation Features
+* Set a callback function to send and play raw audio data for potential sound synthesis.
+* Send raw data for both left and right stereo channels.
+* Track passage of audio frame time for oscillators / time-sensitive applications.
+
 *** Advanced Features, for those who want to use more of miniaudio
 * Get a pointer to the ma_device
-* Get a poitner to the ma_engine
+* Get a pointer to the ma_engine
+* Get pointers to waveforms and sounds
 
 # Usage
 

--- a/demo/demo_synthesis.cpp
+++ b/demo/demo_synthesis.cpp
@@ -1,0 +1,481 @@
+#define OLC_PGE_APPLICATION
+#include "olcPixelGameEngine.h"
+
+#define OLC_PGEX_MINIAUDIO
+#include "olcPGEX_MiniAudio.h"
+
+constexpr int NOTE_COUNT = 17;
+constexpr float thirtyFramesPerSecond = 1.0f / 30.f;
+constexpr float PI = 3.14159f;
+
+class DemoSynthesis : public olc::PixelGameEngine
+{
+    // NOTICE
+    //
+    // This example is highly inspired by the Sound Synthesizer Part 3 series created by javidx9!
+    // Checkout the original at https://github.com/OneLoneCoder/synth/blob/master/main3a.cpp
+    // and the accompanying video at https://www.youtube.com/watch?v=kDuvruJTjOs
+    //
+
+public:
+    DemoSynthesis()
+    {
+        sAppName = "Demo MiniAudio - Custom Audio Synthesis";
+    }
+    
+public:
+
+    bool OnUserCreate() override
+    {
+		instruments.emplace_back(std::make_unique<Harmonica>());
+		instruments.emplace_back(std::make_unique<Bell>());
+		instruments.emplace_back(std::make_unique<Bell8>());
+		instruments.emplace_back(std::make_unique<SawAnalog>());
+
+		// This is it... This is how we interface into the miniaudio engine any noise we want heard!
+		// Fill up the noiseLeftChannel and noiseRightChannel with a value at any given moment...
+		// Accumulate fElapsedTime so that we know how much total time has passed so we can play the correct synthesized sound based on delta time.
+        noiseCallbackFunc = [this](float& noiseLeftChannel, float& noiseRightChannel, const float fElapsedTime)->void{
+			noiseLeftChannel = noiseRightChannel = 0.f;
+
+			for(Note& note : notes)
+			{
+				bool noteFinished{false};
+				float noise = note.instrument->sound(audioRuntime, note, noteFinished); 
+
+				noiseLeftChannel += noise * lerp(0.f, 1.f, pan/2 + 0.5f); // This lerp formula shrinks the -1 to 1 range to 0 to 1, which determines percentage of the total noise to play in each side.
+				noiseRightChannel += noise * lerp(1.f, 0.f, pan/2 + 0.5f);
+			}
+
+			// Each frame the callback receives will give us a duration that frame takes up in real time.
+			audioRuntime += fElapsedTime;
+		};
+
+		// And finally... Tell the system this is where to send audio requests to... Now we can modify audio!
+		ma.SetNoiseCallback(noiseCallbackFunc);
+
+		//Initialize an instrument for all the notes.
+		for(Note& note : notes)
+		{
+			note.instrument = instruments[selectedInstrumentInd].get();
+		}
+
+        return true;
+    }
+    
+    bool OnUserUpdate(float fElapsedTime) override
+    {
+        fElapsedTime = (fElapsedTime > thirtyFramesPerSecond) ? thirtyFramesPerSecond : fElapsedTime;
+        
+        olc::Pixel backgroundCol{olc::VERY_DARK_GREY};
+
+        if(clickToStart)
+        {
+            if(GetMouse(olc::Mouse::LEFT).bPressed)
+                clickToStart=false;
+
+            GradientFillRectDecal({}, {float(ScreenWidth()), ScreenHeight()/2.f}, olc::BLACK, backgroundCol, backgroundCol, olc::BLACK);
+            GradientFillRectDecal({0.f, ScreenHeight()/2.f}, {float(ScreenWidth()), ScreenHeight()/2.f}, backgroundCol, olc::BLACK, olc::BLACK, backgroundCol);
+            olc::vf2d clickToStartTextSize{GetTextSize("Click to Start!")};
+            DrawRotatedStringDecal({ScreenWidth()/2.f, 128.f}, "Click to Start!", 0.f, clickToStartTextSize/2, olc::WHITE, {2.f, 2.f});
+            return true;
+        }
+
+		bool keyPressed{false};
+
+		for(Note& note : notes)
+		{
+			note.instrument->volume = 0.1f;
+
+			if(GetKey(note.key).bHeld)
+			{
+				// Note is not active yet, so we will play it now.
+				if(!note.active)
+				{
+					note.on = audioRuntime;
+					note.active=true;
+				}
+				else
+				if(note.off > note.on) // We pressed the key during its release phase...
+					note.on = audioRuntime;
+
+				keyPressed = true;
+			}
+			else
+			{
+				if(note.off < note.on)
+				{
+					note.off = audioRuntime;
+				}
+			}
+		}
+
+		if(GetKey(olc::UP).bPressed)
+			selectedInstrumentInd = (selectedInstrumentInd + 1) % instruments.size();
+
+		if(GetKey(olc::DOWN).bPressed)
+		{
+			selectedInstrumentInd--;
+			while(selectedInstrumentInd < 0)
+				selectedInstrumentInd += instruments.size();
+		}
+
+		if(GetKey(olc::RIGHT).bHeld)
+			volume = std::min(1.f, volume + 1.f * fElapsedTime);
+		if(GetKey(olc::LEFT).bHeld)
+			volume = std::max(0.f, volume - 1.f * fElapsedTime);
+
+		if(GetKey(olc::O).bHeld)
+			pan = std::min(1.f, pan + 1.f * fElapsedTime);
+		if(GetKey(olc::P).bHeld)
+			pan = std::max(-1.f, pan - 1.f * fElapsedTime);
+
+		if(GetKey(olc::R).bPressed)
+		{
+			selectedInstrumentInd = 0;
+			volume = 0.1f;
+			pan = 0.f;
+		}
+
+		// Update all the notes' instruments.
+		for(Note& note : notes)
+		{
+			note.instrument = instruments[selectedInstrumentInd].get();
+		}
+
+		instruments[selectedInstrumentInd]->volume = volume;
+
+        if(keyPressed)
+            backgroundCol = olc::VERY_DARK_BLUE;
+		
+        GradientFillRectDecal({}, {float(ScreenWidth()), ScreenHeight()/2.f}, olc::BLACK, backgroundCol, backgroundCol, olc::BLACK);
+        GradientFillRectDecal({0.f, ScreenHeight()/2.f}, {float(ScreenWidth()), ScreenHeight()/2.f}, backgroundCol, olc::BLACK, olc::BLACK, backgroundCol);
+
+		DrawStringDecal({},"Instrument: <"+ instruments[selectedInstrumentInd]->name +"> UP, DOWN");
+		DrawStringDecal({0.f, 8.f},"Volume: <"+ std::to_string(volume) +"> LEFT, RIGHT");
+		DrawStringDecal({0.f, 16.f},"Pan: <"+ std::to_string(pan) +"> O, P");
+
+		DrawStringDecal({0.f, 128.f},"Reset Settings <R>");
+
+        #if defined(__EMSCRIPTEN__)
+            return true;
+        #else
+            return !GetKey(olc::ESCAPE).bPressed;
+        #endif
+    }
+
+    // The instance of the audio engine, no fancy config required.
+    olc::MiniAudio ma;
+
+	std::function<void(float& noiseLeftChannel, float& noiseRightChannel, const float fElapsedTime)> noiseCallbackFunc;
+
+    bool clickToStart{true};
+
+	double audioRuntime{}; // A running timer of how long the audio engine has been running.
+
+	float volume{0.1f};
+	float pan{0.0f}; // -1.f for only left channel, 1.f for only right channel
+	
+	struct Instrument;
+
+	struct Note
+	{
+		std::string displayStr;
+		olc::Key key;
+		int id;		// Position in scale
+		float on;	// Time note was activated
+		float off;	// Time note was deactivated
+		bool active;
+		Instrument*instrument;
+
+		Note(std::string displayStr, olc::Key key, int id)
+		:displayStr(displayStr), key(key), id(id){
+			on = 0.0;
+			off = 0.0;
+			active = false;
+		}
+	};
+
+    std::array<Note,NOTE_COUNT>notes{
+        Note
+        {"G#", olc::A,		-1}, //This is not a typo. javid's original scale formula starts at "A", so this will retrieve the note ID prior to that one.
+        {"A" , olc::Z,		0},
+        {"A#", olc::S,		1},
+        {"B" , olc::X,		2},
+        {"C" , olc::C,		3},
+        {"C#", olc::F,		4},
+        {"D" , olc::V,		5},
+        {"D#", olc::G,		6},
+        {"E" , olc::B,		7},
+        {"F" , olc::N,		8},
+        {"F#", olc::J,		9},
+        {"G" , olc::M,		10},
+        {"G#", olc::K,		11},
+        {"A" , olc::COMMA,	12},
+        {"A#", olc::L,		13},
+        {"B" , olc::PERIOD,	14},
+        {"C" , olc::OEM_2,	15},
+    };
+
+	int selectedInstrumentInd{};
+	std::vector<std::unique_ptr<Instrument>>instruments;
+
+    enum class Oscillator
+	{
+		SINE,
+		SQUARE,
+		TRIANGLE,
+		SAW_ANALOG,
+		SAW_DIGITAL,
+		NOISE,
+	};
+
+	float lerp(float n1,float n2,double t){
+		return float(n1*(1-t)+n2*t);
+	}
+
+	// Converts frequency (Hz) to angular velocity
+	static float w(const float hertz)
+	{
+		return hertz * 2.0 * PI;
+	}
+
+	static float osc(const float time, const float hertz, const Oscillator type = Oscillator::SINE,
+		const float LFOHertz = 0.0, const float LFOAmplitude = 0.0, float custom = 50.0)
+	{
+
+		float freq = w(hertz) * time + LFOAmplitude * hertz * (sin(w(LFOHertz) * time));
+
+		switch (type)
+		{
+			case Oscillator::SINE: // Sine wave bewteen -1 and +1
+				return sin(freq);
+
+			case Oscillator::SQUARE: // Square wave between -1 and +1
+				return sin(freq) > 0 ? 1.0 : -1.0;
+
+			case Oscillator::TRIANGLE: // Triangle wave between -1 and +1
+				return asin(sin(freq)) * (2.0 / PI);
+
+			case Oscillator::SAW_ANALOG: // Saw wave (analogue / warm / slow)
+			{
+				float dOutput = 0.0;
+				for (float n = 1.0; n < custom; n++)
+					dOutput += (sin(n*freq)) / n;
+				return dOutput * (2.0 / PI);
+			}
+
+			case Oscillator::SAW_DIGITAL:
+				return atan(tan(freq));
+
+			case Oscillator::NOISE:
+				return 2.0 * ((float)rand() / (float)RAND_MAX) - 1.0;
+
+			default:
+				return 0.0;
+		}
+	}
+
+	//Abstract envelope class
+	struct Envelope
+	{
+		virtual float amplitude(const float time, const float timeOn, const float timeOff) = 0;
+	};
+
+	struct EnvelopeADSR : public Envelope
+	{
+		float attackTime;
+		float decayTime;
+		float sustainAmplitude;
+		float releaseTime;
+		float startAmplitude;
+
+		EnvelopeADSR()
+		{
+			attackTime = 0.1;
+			decayTime = 0.1;
+			sustainAmplitude = 1.0;
+			releaseTime = 0.2;
+			startAmplitude = 1.0;
+		}
+
+		virtual float amplitude(const float time, const float timeOn, const float timeOff)
+		{
+			float dAmplitude = 0.0;
+			float dReleaseAmplitude = 0.0;
+
+			if (timeOn > timeOff) // Note is on
+			{
+				float dLifeTime = time - timeOn;
+
+				if (dLifeTime <= attackTime)
+					dAmplitude = (dLifeTime / attackTime) * startAmplitude;
+
+				if (dLifeTime > attackTime && dLifeTime <= (attackTime + decayTime))
+					dAmplitude = ((dLifeTime - attackTime) / decayTime) * (sustainAmplitude - startAmplitude) + startAmplitude;
+
+				if (dLifeTime > (attackTime + decayTime))
+					dAmplitude = sustainAmplitude;
+			}
+			else // Note is off
+			{
+				float dLifeTime = timeOff - timeOn;
+
+				if (dLifeTime <= attackTime)
+					dReleaseAmplitude = (dLifeTime / attackTime) * startAmplitude;
+
+				if (dLifeTime > attackTime && dLifeTime <= (attackTime + decayTime))
+					dReleaseAmplitude = ((dLifeTime - attackTime) / decayTime) * (sustainAmplitude - startAmplitude) + startAmplitude;
+
+				if (dLifeTime > (attackTime + decayTime))
+					dReleaseAmplitude = sustainAmplitude;
+
+				dAmplitude = ((time - timeOff) / releaseTime) * (0.0 - dReleaseAmplitude) + dReleaseAmplitude;
+			}
+
+			// Amplitude should not be negative
+			if (dAmplitude <= 0.000)
+				dAmplitude = 0.0;
+
+			return dAmplitude;
+		}
+	};
+
+	static float scale(const int noteID)
+	{
+		return 256 * pow(1.0594630943592952645618252949463, noteID);
+	}
+
+	static float envelope(const float time, Envelope &env, const float timeOn, const float timeOff)
+	{
+		return env.amplitude(time, timeOn, timeOff);
+	}
+
+	//An abstract struct for other instruments
+	struct Instrument
+	{
+		float volume;
+		std::string name;
+		EnvelopeADSR env;
+		virtual float sound(const float time, Note&n, bool &bNoteFinished) = 0;
+	};
+
+	struct Bell : public Instrument
+	{
+		Bell()
+		{
+			env.attackTime = 0.01;
+			env.decayTime = 1.0;
+			env.sustainAmplitude = 0.0;
+			env.releaseTime = 1.0;
+
+			volume = 1.0;
+			name = "Bell";
+		}
+
+		virtual float sound(const float time, Note&n, bool &noteFinished) override
+		{
+			float amplitude = envelope(time, env, n.on, n.off);
+			if (amplitude <= 0.0) noteFinished = true;
+
+			float sound =
+				+ 1.00 * osc(n.on - time, scale(n.id + 12), Oscillator::SINE, 5.0, 0.001)
+				+ 0.50 * osc(n.on - time, scale(n.id + 24))
+				+ 0.25 * osc(n.on - time, scale(n.id + 36));
+
+			return amplitude * sound * volume;
+		}
+
+	};
+
+	struct Bell8 : public Instrument
+	{
+		Bell8()
+		{
+			env.attackTime = 0.01;
+			env.decayTime = 0.5;
+			env.sustainAmplitude = 0.8;
+			env.releaseTime = 1.0;
+
+			volume = 1.0;
+			name = "Bell 8-bit";
+		}
+
+		virtual float sound(const float dTime, Note&n, bool &bNoteFinished) override
+		{
+			float amplitude = envelope(dTime, env, n.on, n.off);
+			if (amplitude <= 0.0) bNoteFinished = true;
+
+			float sound =
+				+1.00 * osc(n.on - dTime, scale(n.id), Oscillator::SQUARE, 5.0, 0.001)
+				+ 0.50 * osc(n.on - dTime, scale(n.id + 12))
+				+ 0.25 * osc(n.on - dTime, scale(n.id + 24));
+
+			return amplitude * sound * volume;
+		}
+
+	};
+
+	struct Harmonica : public Instrument
+	{
+		Harmonica()
+		{
+			env.attackTime = 0.05;
+			env.decayTime = 1.0;
+			env.sustainAmplitude = 0.95;
+			env.releaseTime = 0.1;
+
+			volume = 1.0;
+			name = "Harmonica";
+		}
+
+		virtual float sound(const float dTime, Note&n, bool &bNoteFinished) override
+		{
+			float amplitude = envelope(dTime, env, n.on, n.off);
+			if (amplitude <= 0.0) bNoteFinished = true;
+
+			float sound =
+				//+ 1.0  * synth::osc(n.on - dTime, synth::scale(n.id-12), synth::OSC_SAW_ANA, 5.0, 0.001, 100)
+				+ 1.00 * osc(n.on - dTime, scale(n.id), Oscillator::SQUARE, 5.0, 0.001)
+				+ 0.50 * osc(n.on - dTime, scale(n.id + 12), Oscillator::SQUARE)
+				+ 0.05  * osc(n.on - dTime, scale(n.id + 24), Oscillator::NOISE);
+
+			return amplitude * sound * volume;
+		}
+
+	};
+
+	struct SawAnalog : public Instrument
+	{
+		SawAnalog()
+		{
+			env.attackTime = 0.05;
+			env.decayTime = 1.0;
+			env.sustainAmplitude = 0.95;
+			env.releaseTime = 0.1;
+
+			volume = 1.0;
+			name = "Analog Saw";
+		}
+
+		virtual float sound(const float dTime, Note&n, bool &bNoteFinished) override
+		{
+			float amplitude = envelope(dTime, env, n.on, n.off);
+			if (amplitude <= 0.0) bNoteFinished = true;
+
+			float sound =
+				+ 1.00 * osc(n.on - dTime, scale(n.id), Oscillator::SAW_ANALOG, 5.0, 0.001);
+
+			return amplitude * sound * volume;
+		}
+
+	};
+};
+
+int main()
+{
+    DemoSynthesis demo;
+    if (demo.Construct(320, 180, 4, 4))
+        demo.Start();
+    return 0;
+}

--- a/demo/demo_synthesis.cpp
+++ b/demo/demo_synthesis.cpp
@@ -155,7 +155,10 @@ public:
 		DrawStringDecal({0.f, 8.f},"Volume: <"+ std::to_string(volume) +"> LEFT, RIGHT");
 		DrawStringDecal({0.f, 16.f},"Pan: <"+ std::to_string(pan) +"> O, P");
 
-		DrawStringDecal({0.f, 128.f},"Reset Settings <R>");
+		DrawStringDecal({0.f, 120.f},"Reset Settings <R>");
+
+        olc::vf2d pianoStrSize{GetTextSize(piano)};
+        DrawRotatedStringDecal({ScreenWidth()/2.f, ScreenHeight() - pianoStrSize.y/2}, piano, 0.f, pianoStrSize/2, olc::WHITE, {0.65f, 1.f});
 
         #if defined(__EMSCRIPTEN__)
             return true;
@@ -219,6 +222,15 @@ public:
 
 	int selectedInstrumentInd{};
 	std::vector<std::unique_ptr<Instrument>>instruments;
+
+    const std::string piano{
+	    "  | |   |   |   |   | |   |   |   |   | |   | |   |   |   |\n"
+	    "A | | S |   |   | F | | G |   |   | J | | K | | L |   |   |\n"
+	    "__| |___|   |   |___| |___|   |   |___| |___| |___|   |   |__\n"
+	    "|     |     |     |     |     |     |     |     |     |     |\n"
+	    "|  Z  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  |  /  |\n"
+	    "|_____|_____|_____|_____|_____|_____|_____|_____|_____|_____|"
+    };
 
     enum class Oscillator
 	{

--- a/demo/demo_synthesis.cpp
+++ b/demo/demo_synthesis.cpp
@@ -43,8 +43,8 @@ public:
 				bool noteFinished{false};
 				float noise = note.instrument->sound(audioRuntime, note, noteFinished); 
 
-				noiseLeftChannel += noise * lerp(0.f, 1.f, pan/2 + 0.5f); // This lerp formula shrinks the -1 to 1 range to 0 to 1, which determines percentage of the total noise to play in each side.
-				noiseRightChannel += noise * lerp(1.f, 0.f, pan/2 + 0.5f);
+				noiseLeftChannel += noise * lerp(1.f, 0.f, pan/2 + 0.5f); // This lerp formula shrinks the -1 to 1 range to 0 to 1, which determines percentage of the total noise to play in each side.
+				noiseRightChannel += noise * lerp(0.f, 1.f, pan/2 + 0.5f);
 			}
 
 			// Each frame the callback receives will give us a duration that frame takes up in real time.
@@ -126,9 +126,9 @@ public:
 			volume = std::max(0.f, volume - 1.f * fElapsedTime);
 
 		if(GetKey(olc::O).bHeld)
-			pan = std::min(1.f, pan + 1.f * fElapsedTime);
-		if(GetKey(olc::P).bHeld)
 			pan = std::max(-1.f, pan - 1.f * fElapsedTime);
+		if(GetKey(olc::P).bHeld)
+			pan = std::min(1.f, pan + 1.f * fElapsedTime);
 
 		if(GetKey(olc::R).bPressed)
 		{

--- a/demo/demo_synthesis.cpp
+++ b/demo/demo_synthesis.cpp
@@ -413,15 +413,15 @@ public:
 			name = "Bell 8-bit";
 		}
 
-		virtual float sound(const float dTime, Note&n, bool &bNoteFinished) override
+		virtual float sound(const float time, Note&n, bool &noteFinished) override
 		{
-			float amplitude = envelope(dTime, env, n.on, n.off);
-			if (amplitude <= 0.0) bNoteFinished = true;
+			float amplitude = envelope(time, env, n.on, n.off);
+			if (amplitude <= 0.0) noteFinished = true;
 
 			float sound =
-				+1.00 * osc(n.on - dTime, scale(n.id), Oscillator::SQUARE, 5.0, 0.001)
-				+ 0.50 * osc(n.on - dTime, scale(n.id + 12))
-				+ 0.25 * osc(n.on - dTime, scale(n.id + 24));
+				+1.00 * osc(n.on - time, scale(n.id), Oscillator::SQUARE, 5.0, 0.001)
+				+ 0.50 * osc(n.on - time, scale(n.id + 12))
+				+ 0.25 * osc(n.on - time, scale(n.id + 24));
 
 			return amplitude * sound * volume;
 		}
@@ -441,16 +441,16 @@ public:
 			name = "Harmonica";
 		}
 
-		virtual float sound(const float dTime, Note&n, bool &bNoteFinished) override
+		virtual float sound(const float time, Note&n, bool &noteFinished) override
 		{
-			float amplitude = envelope(dTime, env, n.on, n.off);
-			if (amplitude <= 0.0) bNoteFinished = true;
+			float amplitude = envelope(time, env, n.on, n.off);
+			if (amplitude <= 0.0) noteFinished = true;
 
 			float sound =
 				//+ 1.0  * synth::osc(n.on - dTime, synth::scale(n.id-12), synth::OSC_SAW_ANA, 5.0, 0.001, 100)
-				+ 1.00 * osc(n.on - dTime, scale(n.id), Oscillator::SQUARE, 5.0, 0.001)
-				+ 0.50 * osc(n.on - dTime, scale(n.id + 12), Oscillator::SQUARE)
-				+ 0.05  * osc(n.on - dTime, scale(n.id + 24), Oscillator::NOISE);
+				+ 1.00 * osc(n.on - time, scale(n.id), Oscillator::SQUARE, 5.0, 0.001)
+				+ 0.50 * osc(n.on - time, scale(n.id + 12), Oscillator::SQUARE)
+				+ 0.05  * osc(n.on - time, scale(n.id + 24), Oscillator::NOISE);
 
 			return amplitude * sound * volume;
 		}
@@ -470,13 +470,13 @@ public:
 			name = "Analog Saw";
 		}
 
-		virtual float sound(const float dTime, Note&n, bool &bNoteFinished) override
+		virtual float sound(const float time, Note&n, bool &noteFinished) override
 		{
-			float amplitude = envelope(dTime, env, n.on, n.off);
-			if (amplitude <= 0.0) bNoteFinished = true;
+			float amplitude = envelope(time, env, n.on, n.off);
+			if (amplitude <= 0.0) noteFinished = true;
 
 			float sound =
-				+ 1.00 * osc(n.on - dTime, scale(n.id), Oscillator::SAW_ANALOG, 5.0, 0.001);
+				+ 1.00 * osc(n.on - time, scale(n.id), Oscillator::SAW_ANALOG, 5.0, 0.001);
 
 			return amplitude * sound * volume;
 		}

--- a/demo/demo_waveform.cpp
+++ b/demo/demo_waveform.cpp
@@ -1,0 +1,161 @@
+#define OLC_PGE_APPLICATION
+#include "olcPixelGameEngine.h"
+
+#define OLC_PGEX_MINIAUDIO
+#include "olcPGEX_MiniAudio.h"
+
+constexpr int NOTE_COUNT = 17;
+constexpr float thirtyFramesPerSecond = 1.0f / 30.f;
+
+class DemoPiano : public olc::PixelGameEngine
+{
+    // NOTICE
+    //
+    // This example is highly inspired by the Sound Synthesizer Part 1 series created by javidx9!
+    // Checkout the original at https://github.com/OneLoneCoder/synth/blob/master/main1.cpp
+    // and the accompanying video at https://www.youtube.com/watch?v=OSCzKOqtgcA
+    //
+
+    using NoteName = std::string;
+    using Frequency = float;
+
+public:
+    DemoPiano()
+    {
+        sAppName = "Demo MiniAudio - Waveforms";
+    }
+    
+public:
+
+    bool OnUserCreate() override
+    {
+        
+        for(Note&note : notes)
+        {
+            // When calling CreateWaveform, you'll be given a unique ID used in all other Waveform functions. Store it somewhere.
+            note.waveformId = ma.CreateWaveform(amplitude, note.frequency, selectedWaveform);
+        }
+
+        return true;
+    }
+    
+    bool OnUserUpdate(float fElapsedTime) override
+    {
+        fElapsedTime = (fElapsedTime > thirtyFramesPerSecond) ? thirtyFramesPerSecond : fElapsedTime;
+
+        bool keyPressed{false};
+
+        if(GetKey(olc::Q).bPressed)
+        {
+            selectedWaveform = ma_waveform_type((selectedWaveform+1)%4);
+        }
+        if(GetKey(olc::UP).bPressed)
+        {
+            amplitude = std::min(1.f, amplitude + 0.1f);
+        }
+        if(GetKey(olc::DOWN).bPressed)
+        {
+            amplitude = std::max(0.f, amplitude - 0.1f);
+        }
+        
+        for(Note&note : notes)
+        {
+            if(GetKey(note.key).bPressed)
+            {
+                ma.PlayWaveform(note.waveformId);
+            }
+            if(GetKey(note.key).bReleased)
+            {
+                ma.StopWaveform(note.waveformId);
+            }
+            if(GetKey(note.key).bHeld)
+            {
+                keyPressed=true;
+            }
+            ma.SetWaveformType(note.waveformId, selectedWaveform);
+            ma.SetWaveformAmplitude(note.waveformId, amplitude);
+        }
+        
+        olc::Pixel backgroundCol{olc::VERY_DARK_GREY};
+        if(keyPressed)
+            backgroundCol = olc::VERY_DARK_BLUE;
+
+        GradientFillRectDecal({}, {float(ScreenWidth()), ScreenHeight()/2.f}, olc::BLACK, backgroundCol, backgroundCol, olc::BLACK);
+        GradientFillRectDecal({0.f, ScreenHeight()/2.f}, {float(ScreenWidth()), ScreenHeight()/2.f}, backgroundCol, olc::BLACK, olc::BLACK, backgroundCol);
+
+        DrawStringDecal({}, "Waveform Type < " + waveformToName.at(selectedWaveform) + " >   Q");
+        std::stringstream s;
+        s << std::fixed << std::setprecision(1) << amplitude;
+        DrawStringDecal({0,8}, "Amplitude < " + s.str() + " >   UP, DOWN");
+
+        olc::vf2d pianoStrSize{GetTextSize(piano)};
+        DrawRotatedStringDecal({ScreenWidth()/2.f, 128.f}, piano, 0.f, pianoStrSize/2, olc::WHITE, {0.65f, 1.f});
+
+        #if defined(__EMSCRIPTEN__)
+            return true;
+        #else
+            return !GetKey(olc::ESCAPE).bPressed;
+        #endif
+    }
+
+    // The instance of the audio engine, no fancy config required.
+    olc::MiniAudio ma;
+
+    ma_waveform_type selectedWaveform{ma_waveform_type_sine};
+    float amplitude{0.1f};
+
+    struct Note
+    {
+        std::string displayName;
+        float frequency;
+        olc::Key key;
+        int waveformId;
+    };
+
+    std::array<Note,NOTE_COUNT>notes{
+        Note
+        {"G#",  207.65f,    olc::A},
+        {"A",   220.00f,    olc::Z},
+        {"A#",  233.08f,    olc::S},
+        {"B",   246.94f,    olc::X},
+        {"C",   261.63f,    olc::C},
+        {"C#",  277.18f,    olc::F},
+        {"D",   293.66f,    olc::V},
+        {"D#",  311.13f,    olc::G},
+        {"E",   329.63f,    olc::B},
+        {"F",   349.23f,    olc::N},
+        {"F#",  369.99f,    olc::J},
+        {"G",   392.f,      olc::M},
+        {"G#",  415.3f,     olc::K},
+        {"A",   440.f,      olc::COMMA},
+        {"A#",  466.16f,    olc::L},
+        {"B",   493.88f,    olc::PERIOD},
+        {"C",   523.25f,    olc::OEM_2},
+    };
+
+    const std::unordered_map<ma_waveform_type,std::string>waveformToName
+    {
+        {ma_waveform_type_sine,"SINE"},
+        {ma_waveform_type_square,"SQUARE"},
+        {ma_waveform_type_triangle,"TRIANGLE"},
+        {ma_waveform_type_sawtooth,"SAWTOOTH"},
+    };
+
+    const std::string piano{
+	    "  | |   |   |   |   | |   |   |   |   | |   | |   |   |   |\n"
+	    "A | | S |   |   | F | | G |   |   | J | | K | | L |   |   |\n"
+	    "__| |___|   |   |___| |___|   |   |___| |___| |___|   |   |__\n"
+	    "|     |     |     |     |     |     |     |     |     |     |\n"
+	    "|  Z  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  |  /  |\n"
+	    "|_____|_____|_____|_____|_____|_____|_____|_____|_____|_____|"
+    };
+
+};
+
+int main()
+{
+    DemoPiano demo;
+    if (demo.Construct(320, 180, 4, 4))
+        demo.Start();
+    return 0;
+}

--- a/demo/demo_waveform.cpp
+++ b/demo/demo_waveform.cpp
@@ -98,6 +98,18 @@ public:
         #endif
     }
 
+    bool OnUserDestroy() override
+    {
+        
+        for(Note&note : notes)
+        {
+            //Let's be nice and cleanup after ourselves...
+            ma.UnloadWaveform(note.waveformId);
+        }
+
+        return true;
+    }
+
     // The instance of the audio engine, no fancy config required.
     olc::MiniAudio ma;
 

--- a/demo/demo_waveform.cpp
+++ b/demo/demo_waveform.cpp
@@ -30,7 +30,7 @@ public:
     bool OnUserCreate() override
     {
         
-        for(Note&note : notes)
+        for (Note&note : notes)
         {
             // When calling CreateWaveform, you'll be given a unique ID used in all other Waveform functions. Store it somewhere.
             note.waveformId = ma.CreateWaveform(amplitude, note.frequency, selectedWaveform);
@@ -42,6 +42,20 @@ public:
     bool OnUserUpdate(float fElapsedTime) override
     {
         fElapsedTime = (fElapsedTime > thirtyFramesPerSecond) ? thirtyFramesPerSecond : fElapsedTime;
+        
+        olc::Pixel backgroundCol{olc::VERY_DARK_GREY};
+
+        if(clickToStart)
+        {
+            if(GetMouse(olc::Mouse::LEFT).bPressed)
+                clickToStart=false;
+
+            GradientFillRectDecal({}, {float(ScreenWidth()), ScreenHeight()/2.f}, olc::BLACK, backgroundCol, backgroundCol, olc::BLACK);
+            GradientFillRectDecal({0.f, ScreenHeight()/2.f}, {float(ScreenWidth()), ScreenHeight()/2.f}, backgroundCol, olc::BLACK, olc::BLACK, backgroundCol);
+            olc::vf2d clickToStartTextSize{GetTextSize("Click to Start!")};
+            DrawRotatedStringDecal({ScreenWidth()/2.f, 128.f}, "Click to Start!", 0.f, clickToStartTextSize/2, olc::WHITE, {2.f, 2.f});
+            return true;
+        }
 
         bool keyPressed{false};
 
@@ -58,7 +72,7 @@ public:
             amplitude = std::max(0.f, amplitude - 0.1f);
         }
         
-        for(Note&note : notes)
+        for (Note&note : notes)
         {
             if(GetKey(note.key).bPressed)
             {
@@ -76,7 +90,6 @@ public:
             ma.SetWaveformAmplitude(note.waveformId, amplitude);
         }
         
-        olc::Pixel backgroundCol{olc::VERY_DARK_GREY};
         if(keyPressed)
             backgroundCol = olc::VERY_DARK_BLUE;
 
@@ -87,6 +100,20 @@ public:
         std::stringstream s;
         s << std::fixed << std::setprecision(1) << amplitude;
         DrawStringDecal({0,8}, "Amplitude < " + s.str() + " >   UP, DOWN");
+        
+        for (float drawY{24}; Note&note : notes)
+        {
+            if(!ma.IsWaveformPlaying(note.waveformId))
+                continue;
+
+            if(drawY == 24)
+                DrawStringDecal({0.f, drawY - 8.f},"Playing: ");
+
+            std::stringstream notePlayingStr;
+            notePlayingStr << std::setw(5) << note.displayName << std::setw(7) << std::fixed << std::setprecision(2) << note.frequency;
+            DrawStringDecal({0.f, drawY}, "   "+ notePlayingStr.str());
+            drawY += 8;
+        }
 
         olc::vf2d pianoStrSize{GetTextSize(piano)};
         DrawRotatedStringDecal({ScreenWidth()/2.f, 128.f}, piano, 0.f, pianoStrSize/2, olc::WHITE, {0.65f, 1.f});
@@ -97,11 +124,10 @@ public:
             return !GetKey(olc::ESCAPE).bPressed;
         #endif
     }
-
     bool OnUserDestroy() override
     {
         
-        for(Note&note : notes)
+        for (Note&note : notes)
         {
             //Let's be nice and cleanup after ourselves...
             ma.UnloadWaveform(note.waveformId);
@@ -115,6 +141,8 @@ public:
 
     ma_waveform_type selectedWaveform{ma_waveform_type_sine};
     float amplitude{0.1f};
+
+    bool clickToStart{true};
 
     struct Note
     {
@@ -137,9 +165,9 @@ public:
         {"E",   329.63f,    olc::B},
         {"F",   349.23f,    olc::N},
         {"F#",  369.99f,    olc::J},
-        {"G",   392.f,      olc::M},
-        {"G#",  415.3f,     olc::K},
-        {"A",   440.f,      olc::COMMA},
+        {"G",   392.00f,    olc::M},
+        {"G#",  415.30f,    olc::K},
+        {"A",   440.00f,    olc::COMMA},
         {"A#",  466.16f,    olc::L},
         {"B",   493.88f,    olc::PERIOD},
         {"C",   523.25f,    olc::OEM_2},
@@ -147,10 +175,10 @@ public:
 
     const std::unordered_map<ma_waveform_type,std::string>waveformToName
     {
-        {ma_waveform_type_sine,"SINE"},
-        {ma_waveform_type_square,"SQUARE"},
-        {ma_waveform_type_triangle,"TRIANGLE"},
-        {ma_waveform_type_sawtooth,"SAWTOOTH"},
+        {ma_waveform_type_sine, "SINE"},
+        {ma_waveform_type_square, "SQUARE"},
+        {ma_waveform_type_triangle, "TRIANGLE"},
+        {ma_waveform_type_sawtooth, "SAWTOOTH"},
     };
 
     const std::string piano{

--- a/olcPGEX_MiniAudio.h
+++ b/olcPGEX_MiniAudio.h
@@ -158,7 +158,8 @@ namespace olc
         // the callback provides two floating point values to override, one for the left channel and one for the right channel. fill them with raw audio data.
         // for periodic functions, you can reference the fElapsedTime variable to track how much time passed this frame. Accumulate it somewhere to keep track of the total audio time.
         // if you do not change the output channels, the values previously used will be played.
-        void SetNoiseCallback(std::function<void(float& out_audio_data_left, float& out_audio_data_right, const float fElapsedTime)>callbackFunc);
+        void SetNoiseCallback(std::function<void(float& noiseLeftChannel, float& noiseRightChannel, const float fElapsedTime)>callbackFunc);
+        // clears the noise callback and resets the channel values to 0.0
         void ClearNoiseCallback();
         
     public: // ADVANCED FEATURES for those who want to use more of miniaudio
@@ -354,7 +355,6 @@ namespace olc
         */
 
         const int CHANNEL_COUNT{2};
-        const ma_uint32 SAMPLE_RATE{48000};
         using PlaybackFormat = float;
 
         ma_result result;
@@ -373,14 +373,13 @@ namespace olc
 
             if(noiseCallback)
             {
-                // NOTE: we are assuming a sample rate of 48000!
                 for(int i = 0; i < frameCount; i++)
                 {
                     // we send multiple callbacks into the future to get what sound we should be playing...
                     // for raw music data from programs like emulators, the user will probably just keep sending the same sound until it changes on their end.
                     // for periodic functions, they can use the elapsed time this callback sends to accurately determine what
                     // data should be sent precisely at that moment...
-                    noiseCallback(noiseLeftChannel,noiseRightChannel,float(i) / SAMPLE_RATE);
+                    noiseCallback(noiseLeftChannel, noiseRightChannel, 1.f / pDevice->sampleRate);
 
                     // Since we're reading each channel in individually, They have to be interlaced. Each frame we read one value from the left and right channel...
                     // From the miniaudio documentation
@@ -705,7 +704,7 @@ namespace olc
             throw MiniAudioWaveformException();
     }
 
-    void MiniAudio::SetNoiseCallback(std::function<void(float& out_audio_data_left, float& out_audio_data_right, const float fElapsedTime)>callbackFunc)
+    void MiniAudio::SetNoiseCallback(std::function<void(float& noiseLeftChannel, float& noiseRightChannel, const float fElapsedTime)>callbackFunc)
     {
         noiseCallback = callbackFunc;
     }

--- a/olcPGEX_MiniAudio.h
+++ b/olcPGEX_MiniAudio.h
@@ -344,9 +344,6 @@ namespace olc
 
     void MiniAudio::data_callback(ma_device* pDevice, void* pOutput, const void* pInput, ma_uint32 frameCount)
     {
-        // the run time of the audio callback engine, useful for periodic functions playing through the custom callback.
-        static double runTime{};
-
         if(!MiniAudio::backgroundPlay && !pge->IsFocused())
             return;
 
@@ -383,7 +380,7 @@ namespace olc
                     // for raw music data from programs like emulators, the user will probably just keep sending the same sound until it changes on their end.
                     // for periodic functions, they can use the elapsed time this callback sends to accurately determine what
                     // data should be sent precisely at that moment...
-                    noiseCallback(noiseLeftChannel,noiseRightChannel,runTime + float(i) / SAMPLE_RATE);
+                    noiseCallback(noiseLeftChannel,noiseRightChannel,float(i) / SAMPLE_RATE);
 
                     // Since we're reading each channel in individually, They have to be interlaced. Each frame we read one value from the left and right channel...
                     // From the miniaudio documentation
@@ -437,8 +434,6 @@ namespace olc
                 break;  /* Reached EOF. */
             }
         }
-
-        runTime += double(totalFramesRead)/SAMPLE_RATE;
     }
     
     void MiniAudio::SetBackgroundPlay(bool state)

--- a/olcPGEX_MiniAudio.h
+++ b/olcPGEX_MiniAudio.h
@@ -124,7 +124,7 @@ namespace olc
         float GetCursorFloat(const int id);
 
 
-    public: //WAVEFORM AND NOISE GENERATION
+    public: // WAVEFORM AND NOISE GENERATION
         struct Waveform;
         // creates a new waveform and returns the id of the waveform
         const int CreateWaveform(const double amplitude, const double frequency, const ma_waveform_type waveformType);
@@ -206,7 +206,7 @@ namespace olc
 
         static float noiseLeftChannel;
         static float noiseRightChannel;
-        static std::function<void(float& out_data_channel_left, float& const out_data_channel_right, const float fElapsedTime)> noiseCallback;
+        static std::function<void(float& out_data_channel_left, float& out_data_channel_right, const float fElapsedTime)> noiseCallback;
     };
 
     /**


### PR DESCRIPTION
Adds the following features to olcPGEX_MiniAudio:

- Create and Play generated waveforms provided by MiniAudio. Types include: Sine waves, Square Waves, Triangle Waves, and Sawtooth Waves.
- Adjust waveform type, amplitude, and frequency on the fly.
- Unload waveform function and getter for direct ma_waveform objects included.
- Works similar to the id system that the sound system uses.

- Define a custom audio callback function that allows the user to send custom audio data to both stereo channels of MiniAudio. This audio will be auto-mixed and layered with the rest of the available sounds that the MiniAudio engine plays.
- Clear the audio callback which also resets the sound coming from it.

These are clearly targeted towards users who are mostly interested in generating sounds from scratch without relying on loading files.

Two new demo files are also included to demonstrate the new capabilities of the PGEX.