### PR TITLE
Synthesis demo Input fix

### DIFF
--- a/demo/demo_synthesis.cpp
+++ b/demo/demo_synthesis.cpp
@@ -95,6 +95,8 @@ public:
 				{
 					note.off = audioRuntime;
 				}
+
+				note.active = false;
 			}
 		}
 


### PR DESCRIPTION
This fixes the Synthesis demo:

- If a note is pressed, released, and pressed again quick enough, the note will become stuck in the active state and will no longer emit any sound. Highly reproducible on the emscripten build. Technically possible on a native build, but harder to pull off due to less latency. This one-line change corrects this behavior.